### PR TITLE
jdk version fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk11
 
 script: mvn -f carparkpractice/pom.xml test -B
 


### PR DESCRIPTION
For some reason when re-using travis through chrome, build failed due to jdk version being 8 not 11